### PR TITLE
command: Add a version subcommand

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,8 @@
+.PHONY: all install
+
+VERSION = $(shell git log -n1 --no-merges --pretty="%h %cd")
+
+all: install
+
+install:
+	go install -ldflags="-X 'github.com/jtepe/gopodgrab/cmd.Version=$(VERSION)'"

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -14,7 +14,7 @@ It lets you download, update, and search your list of podcasts and episodes.`,
 }
 
 func init() {
-	rootCmd.AddCommand(addCmd, listCmd, showCmd)
+	rootCmd.AddCommand(addCmd, listCmd, showCmd, versionCmd)
 }
 
 func Execute() {

--- a/cmd/version.go
+++ b/cmd/version.go
@@ -1,0 +1,18 @@
+package cmd
+
+import (
+	"fmt"
+
+	"github.com/spf13/cobra"
+)
+
+var Version = "development"
+
+var versionCmd = &cobra.Command{
+	Use:   "version",
+	Short: "Print version",
+	Long:  "Show the full version information from gopodgrab.",
+	Run: func(cmd *cobra.Command, args []string) {
+		fmt.Println("gopodgrab", Version)
+	},
+}


### PR DESCRIPTION
Adds a very basic version subcommand, e.g.:
`gopodgrab version`

This will, by default, output the SHA and date of the latest commit.

For convenient build, a very simple Makefile is included.